### PR TITLE
Integrate LCD/Buzzer with Flask app via HardwareController

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,9 @@ This document provides guidelines for AI agents working on this codebase.
 
 ## GPIO Pin Numbering
 
--   The project uses **BCM** pin numbering for `RPi.GPIO`. This is explicitly set in `ip_display_app.py`.
+-   The project uses **BCM** pin numbering for `RPi.GPIO`.
+-   GPIO mode initialization (`GPIO.setmode(GPIO.BCM)`) and global cleanup (`GPIO.cleanup()`) are now handled by `app/hardware_controller.py` when initialized by a main application script (e.g., `run.py` for the Flask app, or `ip_display_app.py` for the standalone utility).
+-   Individual hardware modules (`buzzer_pwm.py`, `lcd_i2c.py`) should not set the GPIO mode or perform global cleanup.
 -   When adding new GPIO-related functionality or modifying existing code, ensure BCM numbering is consistently used.
 
 ## Libraries
@@ -22,18 +24,21 @@ This document provides guidelines for AI agents working on this codebase.
 
 -   Follow standard Python PEP 8 guidelines for code style.
 -   The project is structured with:
-    -   `ip_display_app.py`: Main application logic.
-    -   `lcd_i2c.py`: Class for controlling the I2C LCD.
-    -   `buzzer_pwm.py`: Class for controlling the passive buzzer.
--   New, distinct functionalities should ideally be encapsulated in their own modules or classes if appropriate.
+    -   `run.py`: Main Flask application runner. Initializes and manages hardware via `HardwareController`.
+    -   `app/hardware_controller.py`: Centralized control for LCD and Buzzer. Handles GPIO setup and cleanup. Provides an interface for the Flask app and other utilities to use hardware. Includes mock mode for development off-RPi.
+    -   `app/lcd_i2c.py`: Class for controlling the I2C LCD. (Relies on `smbus2`)
+    -   `app/buzzer_pwm.py`: Class for controlling the passive buzzer. (Relies on `RPi.GPIO`)
+    -   `ip_display_app.py`: Standalone utility to display IP addresses, now uses `app.hardware_controller.py`.
+    -   Flask-specific files (routes, models, forms, templates) are within the `app/` directory.
+-   New, distinct hardware-related functionalities should ideally be added to `app/hardware_controller.py` or as methods to the individual device classes if appropriate.
 -   Include docstrings for modules, classes, and functions to explain their purpose, arguments, and return values.
 -   Add comments to clarify complex or non-obvious code sections.
 
 ## Error Handling
 
--   Implement robust error handling, especially for hardware interactions (I2C, GPIO) and network operations.
+-   Implement robust error handling, especially for hardware interactions (I2C, GPIO) and network operations. `app/hardware_controller.py` includes a mock mode to allow development and testing of the Flask application logic even when Raspberry Pi hardware is not present.
 -   Use `try...except` blocks to catch potential exceptions and provide informative error messages or graceful failure.
--   Ensure GPIO resources are cleaned up properly using `GPIO.cleanup()` in a `finally` block in the main application script.
+-   GPIO resource cleanup (`GPIO.cleanup()`) is handled by `app.hardware_controller.shutdown_hardware()`, which should be called on application exit (e.g., using `atexit` in `run.py`).
 
 ## Testing (Simulated)
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,34 @@
-# Raspberry Pi IP Address Display with LCD and Buzzer
+# Raspberry Pi Face Recognition Based Attendance System with LCD/Buzzer Feedback
 
-This project uses a Raspberry Pi to display its current IP address(es) on a 16x2 I2C LCD and provides auditory feedback using a passive buzzer.
+This project is a Flask-based web application for managing student attendance using facial recognition. It integrates with Raspberry Pi hardware (I2C LCD and Passive Buzzer) to provide real-time feedback during the attendance process and can display system status like IP address.
 
 ## Features
 
--   Displays IP addresses for Ethernet (`eth0`) and WLAN (`wlan0`) interfaces.
--   Shows "No IP Found" or "Check Network" if IP addresses are not available.
--   Updates the display periodically.
--   Plays a startup sound.
--   Provides a shutdown sound and message on graceful exit (Ctrl+C).
--   Error indication via LCD and buzzer.
+**Core Application (Flask Web Interface):**
+-   Admin login and dashboard.
+-   Student Management: Add, edit, delete students with photo uploads for facial recognition.
+-   Exam Management: Create, edit, delete exams (subject, date, time).
+-   Exam Registration: Register students for specific exams.
+-   Live Authentication: Real-time facial recognition during exams using a webcam.
+    -   Visual feedback on the web interface (bounding boxes, student names, eligibility status).
+-   Logging: Records authentication attempts (verified, unknown, not eligible) with timestamps.
+-   Log Viewing: Paginated and sortable view of authentication logs.
+
+**Raspberry Pi Hardware Integration (LCD & Buzzer):**
+-   **On Flask App Start:**
+    -   LCD displays "Flask App Ready" (or similar) and the Raspberry Pi's IP address and port.
+    -   Buzzer plays a startup sound.
+-   **During Operation (Examples - can be extended):**
+    -   LCD can show status messages (e.g., "Live Auth Active").
+    -   Buzzer can provide audible cues for events (e.g., successful recognition, errors - *current integration is basic, can be expanded*).
+-   **On Flask App Shutdown:**
+    -   LCD displays "Server Offline" (or similar).
+    -   Buzzer plays a shutdown sound.
+    -   GPIO resources are cleaned up.
+-   **Standalone IP Display Utility (`ip_display_app.py`):**
+    -   A separate script that uses the same hardware controller to display current IP addresses, similar to the original project functionality. This can be run independently of the Flask application.
+-   **Mock Hardware Mode:**
+    -   If RPi-specific libraries are not found (e.g., when developing on a non-RPi machine), the hardware controller switches to a mock mode, printing actions to the console instead of interacting with physical hardware. This allows the Flask application to run and be tested without a Raspberry Pi.
 
 ## Hardware Requirements
 
@@ -60,13 +79,32 @@ Open a terminal on your Raspberry Pi and run the following commands:
 # Update package list
 sudo apt-get update
 
-# Install system-level dependencies for I2C and Python smbus
-sudo apt-get install -y python3-smbus i2c-tools
+# Install system-level dependencies for I2C, Python smbus, build tools, and OpenCV dependencies
+sudo apt-get install -y python3-smbus i2c-tools build-essential cmake libjpeg-dev libpng-dev libtiff-dev libavcodec-dev libavformat-dev libswscale-dev libv4l-dev libxvidcore-dev libx264-dev libgtk-3-dev libatlas-base-dev gfortran python3-dev
 
 # Install necessary Python libraries using pip
-pip3 install RPi.GPIO smbus2
+# It's recommended to use a virtual environment
+# python3 -m venv venv
+# source venv/bin/activate
+pip3 install --upgrade pip
+pip3 install -r requirements.txt
 ```
-*Note: `smbus2` is preferred. If it causes issues, you might already have `python3-smbus` which provides the `smbus` module, and the `lcd_i2c.py` script can be slightly adjusted if needed.*
+The `requirements.txt` file should include:
+- Flask
+- Flask-Login
+- Flask-SQLAlchemy
+- Flask-Migrate
+- Flask-WTF
+- python-dotenv
+- RPi.GPIO (for Raspberry Pi)
+- smbus2 (for Raspberry Pi I2C)
+- face_recognition (and its dependencies like dlib, numpy, Pillow)
+- opencv-python
+- click
+- gunicorn (optional, for production deployment)
+
+*Note: Installing `dlib` (a dependency of `face_recognition`) can be time-consuming and resource-intensive on a Raspberry Pi. Pre-built wheels might be available, or compilation from source will occur.*
+*`smbus2` is preferred for I2C. If it causes issues, `python3-smbus` (system package) provides the `smbus` module.*
 
 ### 3. Check LCD I2C Address (Optional but Recommended)
 
@@ -80,19 +118,62 @@ You should see a table of I2C addresses. Your LCD will likely appear as `27` or 
 
 ## Running the Application
 
-1.  Clone this repository or download the files (`ip_display_app.py`, `lcd_i2c.py`, `buzzer_pwm.py`) to a directory on your Raspberry Pi.
-2.  Navigate to that directory in the terminal:
+### Initial Setup
+
+1.  **Clone the repository:**
     ```bash
-    cd /path/to/your/scripts
-    ```
-3.  Run the main application script:
-    ```bash
-    python3 ip_display_app.py
+    git clone <repository_url>
+    cd <repository_directory>
     ```
 
-The script will initialize the components, play a startup sound, and then display the IP address(es) on the LCD. The display will refresh periodically.
+2.  **Create a `.flaskenv` file** (optional, for development environment variables):
+    ```
+    FLASK_APP=run.py
+    FLASK_ENV=development # Use 'production' for production
+    # DATABASE_URL=sqlite:///site.db # Example, can be configured in config.py
+    # SECRET_KEY=your_very_secret_key # Should be set for sessions
+    ```
+    *Ensure `SECRET_KEY` is set to a strong random value, especially for production.*
 
-To stop the application, press `Ctrl+C`. It will play a shutdown sound, clear the LCD, and clean up GPIO resources.
+3.  **Initialize the Database (Flask-Migrate):**
+    ```bash
+    # If using a virtual environment, activate it first: source venv/bin/activate
+    flask db init  # Run only once to initialize migrations folder
+    flask db migrate -m "Initial migration." # Or a descriptive message
+    flask db upgrade # Apply migrations to the database
+    ```
+
+4.  **Create an Admin User:**
+    ```bash
+    flask create-admin <admin_username> <admin_password>
+    ```
+    Replace `<admin_username>` and `<admin_password>` with your desired credentials.
+
+### Running the Flask Web Application
+
+Navigate to the project's root directory in the terminal.
+
+```bash
+# If using a virtual environment, activate it: source venv/bin/activate
+python3 run.py
+```
+The application will typically start on `http://0.0.0.0:5000/`.
+-   The LCD (if connected and on a Raspberry Pi) will display a startup message and the server's IP address.
+-   The buzzer will play a startup sound.
+-   Access the web interface through a browser on a device connected to the same network, using the Raspberry Pi's IP address (e.g., `http://<RaspberryPi_IP>:5000/`).
+
+To stop the Flask application, press `Ctrl+C` in the terminal where it's running.
+-   The LCD will display a shutdown message.
+-   The buzzer will play a shutdown sound.
+-   GPIO resources will be cleaned up.
+
+### Running the Standalone IP Display Utility
+
+If you only want to display the IP address on the LCD without running the full web application:
+```bash
+python3 ip_display_app.py
+```
+This script uses the same hardware controller for LCD and buzzer operations. Press `Ctrl+C` to stop it.
 
 ## Troubleshooting
 
@@ -105,10 +186,21 @@ To stop the application, press `Ctrl+C`. It will play a shutdown sound, clear th
     -   Ensure the correct GPIO pin (BCM 18 / Pin 12) is used.
 -   **`ImportError: No module named smbus2` (or `smbus`)**:
     -   Ensure you have installed the library using `pip3 install smbus2`.
--   **`RuntimeError: Please set pin numbering mode using GPIO.setmode(GPIO.BOARD) or GPIO.setmode(GPIO.BCM)`**:
-    -   The main script `ip_display_app.py` sets `GPIO.setmode(GPIO.BCM)`. If you run modules independently for testing, ensure you set the mode.
--   **IP Address shows "None" or "No IP Found"**:
+-   **`RuntimeError: Please set pin numbering mode using GPIO.setmode(GPIO.BOARD) or GPIO.setmode(GPIO.BCM)` (when running `buzzer_pwm.py` standalone for testing)**:
+    -   The `app.hardware_controller.py` (used by `run.py` and `ip_display_app.py`) handles `GPIO.setmode(GPIO.BCM)`.
+    -   If testing `buzzer_pwm.py` directly, its `if __name__ == '__main__':` block now includes `GPIO.setmode(GPIO.BCM)` and `GPIO.cleanup()` for that specific test scenario.
+-   **IP Address shows "None", "No IP Found", or "?.?.?.?" on LCD**:
     -   Ensure your Raspberry Pi is connected to the network (Ethernet or Wi-Fi).
     -   Check if the network interfaces (`eth0`, `wlan0`) are active and configured. Use `ifconfig` or `ip a` to check their status.
+    -   The IP detection method in `app.hardware_controller.py` and `run.py` tries its best but might not cover all network configurations.
+-   **Flask Application Errors (e.g., database issues, template not found)**:
+    -   Check the terminal output where `python3 run.py` is executing for detailed Flask error messages.
+    -   Ensure all dependencies in `requirements.txt` are installed correctly in your environment.
+    -   Verify database setup and migrations (`flask db upgrade`).
+-   **Facial Recognition Issues**:
+    -   Ensure `face_recognition` and `opencv-python` are installed correctly.
+    -   Provide clear, well-lit photos for student registration.
+    -   Check webcam connectivity and permissions if using live authentication. The `initialize_camera` function in `app/routes.py` tries multiple camera indices.
+    -   Performance on Raspberry Pi for real-time recognition can be slow; consider lower resolution or frame skipping if needed (some settings in `app/routes.py` `generate_frames`).
 
-Enjoy your IP display!
+Enjoy your integrated attendance system!

--- a/app/hardware_controller.py
+++ b/app/hardware_controller.py
@@ -1,0 +1,301 @@
+import time
+import socket
+import fcntl
+import struct
+try:
+    import RPi.GPIO as GPIO
+    from .lcd_i2c import LCD_I2C, DEFAULT_I2C_ADDR # Use relative import
+    from .buzzer_pwm import PassiveBuzzer, DEFAULT_BUZZER_PIN # Use relative import
+    RPI_HW_AVAILABLE = True
+except (ImportError, RuntimeError) as e:
+    print(f"Warning: Raspberry Pi specific hardware modules (RPi.GPIO, smbus) not found or error during import: {e}. Hardware controller will operate in mock mode.")
+    RPI_HW_AVAILABLE = False
+
+# Configuration
+LCD_I2C_ADDRESS = DEFAULT_I2C_ADDR if RPI_HW_AVAILABLE else 0x27
+BUZZER_GPIO_PIN = DEFAULT_BUZZER_PIN if RPI_HW_AVAILABLE else 18
+NETWORK_INTERFACES = ['eth0', 'wlan0']  # Interfaces to check for IP
+
+# Global hardware component instances
+lcd = None
+buzzer = None
+gpio_initialized = False
+
+def _get_ip_address(ifname):
+    """
+    Gets the IP address of a given network interface.
+    Returns the IP address string or None if not found or interface is down.
+    Mock implementation if not on RPi or network utils fail.
+    """
+    if not RPI_HW_AVAILABLE: # Or more specific check for socket availability if needed
+        print(f"Mock mode: _get_ip_address({ifname}) -> returning '127.0.0.1' or None")
+        if ifname == 'eth0':
+            return '192.168.1.101' # Example
+        elif ifname == 'wlan0':
+            return '192.168.1.102' # Example
+        return None
+
+    try:
+        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        addr = socket.inet_ntoa(fcntl.ioctl(
+            s.fileno(),
+            0x8915,  # SIOCGIFADDR
+            struct.pack('256s', ifname[:15].encode('utf-8'))
+        )[20:24])
+        return addr
+    except IOError: # Interface not found or not up
+        return None
+    except Exception as e:
+        print(f"Error getting IP for {ifname}: {e}")
+        return None
+
+def init_hardware(app_name="Flask App", server_ip="<IP_Pending>", server_port="<Port>"):
+    """
+    Initializes GPIO, LCD, and Buzzer.
+    Displays a startup message on the LCD.
+    Plays a startup sound.
+    """
+    global lcd, buzzer, gpio_initialized
+
+    if not RPI_HW_AVAILABLE:
+        print("Mock mode: init_hardware() called. Simulating hardware initialization.")
+        # Create mock objects if needed for further interaction
+        class MockLCD:
+            def message(self, text, line, col=0): print(f"MockLCD: Line {line}, Col {col}: {text}")
+            def clear(self): print("MockLCD: clear()")
+            def backlight(self, on): print(f"MockLCD: backlight({on})")
+            def display_off(self): print("MockLCD: display_off()")
+        class MockBuzzer:
+            def startup_sound(self): print("MockBuzzer: startup_sound()")
+            def play_tone(self, freq, dur): print(f"MockBuzzer: play_tone({freq}Hz, {dur}s)")
+            def cleanup(self): print("MockBuzzer: cleanup()")
+
+        lcd = MockLCD()
+        buzzer = MockBuzzer()
+        gpio_initialized = True # Simulate success
+
+        lcd.message(app_name, 1)
+        lcd.message(f"{server_ip}:{server_port}", 2)
+        buzzer.startup_sound()
+        print("Mock hardware initialized.")
+        return True
+
+    if gpio_initialized:
+        print("Hardware already initialized.")
+        return True
+
+    try:
+        GPIO.setmode(GPIO.BCM)
+        gpio_initialized = True
+        print("GPIO mode set to BCM.")
+
+        # Initialize LCD
+        try:
+            print(f"Initializing LCD at I2C address 0x{LCD_I2C_ADDRESS:02X}...")
+            lcd = LCD_I2C(i2c_addr=LCD_I2C_ADDRESS)
+            lcd.message("LCD Init OK", 1)
+            print("LCD Initialized.")
+            time.sleep(0.5)
+        except Exception as e:
+            print(f"Error initializing LCD: {e}")
+            lcd = None # Ensure lcd is None if init fails
+
+        # Initialize Buzzer
+        try:
+            print(f"Initializing Buzzer on GPIO {BUZZER_GPIO_PIN}...")
+            buzzer = PassiveBuzzer(buzzer_pin=BUZZER_GPIO_PIN)
+            print("Buzzer Initialized.")
+            buzzer.beep(repeat=2, tone_duration=0.05, pause_duration=0.05, frequency=1500)
+            if lcd:
+                lcd.message("Buzzer Init OK", 2)
+            time.sleep(0.5)
+        except Exception as e:
+            print(f"Error initializing Buzzer: {e}")
+            if lcd:
+                lcd.clear()
+                lcd.message("Buzzer Init FAIL", 1)
+                time.sleep(1)
+            buzzer = None # Ensure buzzer is None if init fails
+
+        if lcd and buzzer:
+            print("LCD and Buzzer OK for Flask App.")
+            lcd.clear()
+            lcd.message(app_name[:16], 1) # Ensure app_name fits
+            ip_info = f"{server_ip}:{server_port}"
+            lcd.message(ip_info[:16], 2) # Ensure IP info fits
+            buzzer.startup_sound()
+            print(f"Displayed: {app_name} | {ip_info}")
+        elif lcd:
+            lcd.clear()
+            lcd.message(app_name[:16], 1, 0)
+            lcd.message("No Buzzer", 2, 0)
+            print(f"Displayed: {app_name} | No Buzzer")
+        elif buzzer:
+            print("LCD failed, Buzzer OK. Playing alert for LCD failure.")
+            buzzer.alert_sound()
+        else:
+            print("CRITICAL: Both LCD and Buzzer failed to initialize for Flask app.")
+            return False
+
+        return True
+
+    except Exception as e:
+        print(f"Error in init_hardware: {e}")
+        gpio_initialized = False # Ensure this is false if setmode fails
+        return False
+
+def shutdown_hardware():
+    """
+    Cleans up GPIO resources, turns off LCD, and plays a shutdown sound.
+    """
+    global lcd, buzzer, gpio_initialized
+
+    print("Shutting down hardware...")
+    if not RPI_HW_AVAILABLE:
+        print("Mock mode: shutdown_hardware() called.")
+        if buzzer: buzzer.play_tone(100, 0.2) # Simulate shutdown sound
+        if lcd:
+            lcd.clear()
+            lcd.message("Server Offline", 1)
+            lcd.backlight(False)
+            lcd.display_off()
+        print("Mock hardware shutdown complete.")
+        return
+
+    if buzzer:
+        try:
+            buzzer.play_tone(200, 0.1) # Short low beep for shutdown
+            buzzer.play_tone(150, 0.1)
+            buzzer.cleanup() # Module specific cleanup
+        except Exception as e:
+            print(f"Error during buzzer shutdown: {e}")
+
+    if lcd:
+        try:
+            lcd.clear()
+            lcd.backlight(True)
+            lcd.message("Server Offline", 1)
+            time.sleep(1)
+            lcd.backlight(False)
+            lcd.display_off()
+        except Exception as e:
+            print(f"Error during LCD shutdown: {e}")
+
+    if gpio_initialized:
+        try:
+            GPIO.cleanup() # Global GPIO cleanup
+            print("GPIO cleanup complete.")
+            gpio_initialized = False
+        except Exception as e:
+            print(f"Error during GPIO cleanup: {e}")
+    else:
+        print("GPIO was not initialized or already cleaned up.")
+    print("Hardware shutdown sequence finished.")
+
+def display_message(line1, line2="", clear_first=True):
+    """Displays messages on the LCD. If LCD is not available, prints to console."""
+    if not RPI_HW_AVAILABLE and not (lcd and hasattr(lcd, 'message')): # Check if mock lcd was created
+        print(f"MockLCD Display: L1: '{line1}', L2: '{line2}'")
+        return
+
+    if lcd:
+        try:
+            if clear_first:
+                lcd.clear()
+            if line1 is not None: # Allow clearing and setting only one line
+                lcd.message(str(line1)[:16], 1) # Max 16 chars
+            if line2 is not None:
+                lcd.message(str(line2)[:16], 2) # Max 16 chars
+        except Exception as e:
+            print(f"Error displaying message on LCD: {e}")
+    else:
+        print("LCD not available. Message not displayed on hardware.")
+        print(f"Intended LCD L1: {line1}")
+        print(f"Intended LCD L2: {line2}")
+
+
+def play_sound(sound_type="beep"):
+    """Plays a predefined sound on the buzzer. If not available, prints to console."""
+    if not RPI_HW_AVAILABLE and not (buzzer and hasattr(buzzer, 'beep')): # Check if mock buzzer was created
+        print(f"MockBuzzer: play_sound('{sound_type}')")
+        return
+
+    if buzzer:
+        try:
+            if sound_type == "beep":
+                buzzer.beep()
+            elif sound_type == "startup":
+                buzzer.startup_sound()
+            elif sound_type == "alert":
+                buzzer.alert_sound()
+            elif sound_type == "confirmation":
+                buzzer.confirmation_beep()
+            elif sound_type == "double_confirmation":
+                buzzer.double_confirmation_beep()
+            else:
+                print(f"Unknown sound type: {sound_type}")
+        except Exception as e:
+            print(f"Error playing sound on buzzer: {e}")
+    else:
+        print(f"Buzzer not available. Sound '{sound_type}' not played on hardware.")
+
+def get_ip_addresses_string():
+    """
+    Returns a string with current IP addresses, formatted for single-line display.
+    e.g., "E:192.168.1.5 W:None"
+    """
+    if not RPI_HW_AVAILABLE:
+        return "E:127.0.0.1 W:N/A" # Mock IP string
+
+    ips = {}
+    for iface in NETWORK_INTERFACES:
+        ips[iface] = _get_ip_address(iface)
+
+    eth_ip = ips.get('eth0')
+    wlan_ip = ips.get('wlan0')
+
+    display_str = ""
+    if eth_ip:
+        display_str += f"E:{eth_ip} "
+    if wlan_ip:
+        display_str += f"W:{wlan_ip}"
+
+    if not display_str:
+        return "No IP Found"
+
+    return display_str.strip()[:16] # Ensure it fits 16 chars
+
+# Example standalone usage for testing hardware_controller.py itself
+if __name__ == '__main__':
+    print("Testing hardware_controller.py...")
+
+    # Attempt to get server IP for display (useful if running this on the device)
+    # This is a simple way, might not always work depending on network config
+    hostname = socket.gethostname()
+    try:
+        local_ip = socket.gethostbyname(hostname)
+    except socket.gaierror:
+        local_ip = "?.?.?.?" # Fallback if hostname doesn't resolve easily
+
+    if init_hardware("Test App", local_ip, "5000"):
+        print("Hardware initialized successfully for test.")
+        display_message("Controller Test", "Running...", clear_first=False) # Append to init message
+        time.sleep(2)
+
+        current_ips_str = get_ip_addresses_string()
+        display_message("IP Info:", current_ips_str)
+        print(f"IPs displayed: {current_ips_str}")
+        time.sleep(3)
+
+        play_sound("confirmation")
+        time.sleep(1)
+        play_sound("alert")
+        time.sleep(2)
+
+        display_message("Test Complete!", "Shutting down...")
+        print("Test complete. Shutting down hardware.")
+    else:
+        print("Hardware initialization failed for test.")
+
+    shutdown_hardware()
+    print("hardware_controller.py test finished.")

--- a/ip_display_app.py
+++ b/ip_display_app.py
@@ -1,216 +1,94 @@
+# This script is now a wrapper around the hardware_controller for standalone IP display.
+# The core logic for hardware interaction has been moved to app.hardware_controller.
+
 import time
-import socket
-import fcntl
-import struct
-import RPi.GPIO as GPIO
+import sys
 
-from lcd_i2c import LCD_I2C, DEFAULT_I2C_ADDR
-from buzzer_pwm import PassiveBuzzer, DEFAULT_BUZZER_PIN
+# Adjust path to import from parent directory's 'app' package if run directly from project root
+# This might be needed if you run `python ip_display_app.py` from the root,
+# and `app` is not automatically in the Python path.
+# However, if `ip_display_app.py` is moved into `app` or project is structured as a package,
+# this might not be necessary or might need adjustment.
+# For simplicity, assuming it can find 'app.hardware_controller' if project root is in PYTHONPATH
+# or if this script is run as part of a package.
+try:
+    from app.hardware_controller import (
+        init_hardware,
+        shutdown_hardware,
+        display_message,
+        play_sound,
+        get_ip_addresses_string,
+        RPI_HW_AVAILABLE
+    )
+except ImportError:
+    # Try adding project root to path if running script directly from its location
+    # and app folder is sibling to it. This is a common scenario.
+    # This is a bit of a hack for standalone script execution.
+    # Better to run as `python -m ip_display_app` if it's part of a package,
+    # or ensure PYTHONPATH is set.
+    import os
+    sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+    try:
+        from app.hardware_controller import (
+            init_hardware,
+            shutdown_hardware,
+            display_message,
+            play_sound,
+            get_ip_addresses_string,
+            RPI_HW_AVAILABLE
+        )
+    except ImportError as e:
+        print("Error: Could not import 'app.hardware_controller'.")
+        print("Make sure this script is run from the project root directory or the 'app' package is in PYTHONPATH.")
+        print(f"Details: {e}")
+        sys.exit(1)
 
-# Configuration
-LCD_I2C_ADDRESS = DEFAULT_I2C_ADDR  # Use the default from lcd_i2c.py or override
-BUZZER_GPIO_PIN = DEFAULT_BUZZER_PIN  # Use the default from buzzer_pwm.py or override
+
 IP_REFRESH_INTERVAL = 30  # Seconds
-NETWORK_INTERFACES = ['eth0', 'wlan0']  # Interfaces to check for IP
 
-def get_ip_address(ifname):
-    """
-    Gets the IP address of a given network interface.
-    Returns the IP address string or None if not found or interface is down.
-    """
-    try:
-        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-        addr = socket.inet_ntoa(fcntl.ioctl(
-            s.fileno(),
-            0x8915,  # SIOCGIFADDR
-            struct.pack('256s', ifname[:15].encode('utf-8'))
-        )[20:24])
-        return addr
-    except IOError: # Interface not found or not up
-        return None
-    except Exception as e:
-        print(f"Error getting IP for {ifname}: {e}")
-        return None
+def main_ip_display():
+    print("Starting Standalone IP Display (using hardware_controller)...")
 
-def get_all_ips(interfaces_to_check):
-    """
-    Gets IP addresses for a list of interfaces.
-    Returns a dictionary {interface_name: ip_address}.
-    IP address will be None if not found for an interface.
-    """
-    ips = {}
-    for iface in interfaces_to_check:
-        ips[iface] = get_ip_address(iface)
-    return ips
+    # Initialize hardware with a specific name for this utility
+    if not init_hardware(app_name="IP Display Util", server_ip="", server_port=""):
+        print("Failed to initialize hardware via controller. Exiting IP display utility.")
+        # shutdown_hardware() # Call shutdown to attempt cleanup if partial init occurred
+        return
 
-def display_ips_on_lcd(lcd, ips_dict):
-    """
-    Displays IP addresses on the LCD.
-    Prioritizes wlan0 then eth0 if both exist for display, or shows multiple if space allows.
-    """
-    lcd.clear()
-    line1_msg = None
-    line2_msg = None
-
-    wlan_ip = ips_dict.get('wlan0')
-    eth_ip = ips_dict.get('eth0')
-
-    if wlan_ip:
-        line1_msg = f"WLAN: {wlan_ip}"
-    if eth_ip:
-        if line1_msg: # WLAN IP is already on line 1
-            line2_msg = f"ETH: {eth_ip}"
-        else: # No WLAN IP, put ETH on line 1
-            line1_msg = f"ETH: {eth_ip}"
-
-    if not line1_msg and not line2_msg:
-        # No IPs found for specified interfaces
-        active_ips = [f"{ifname}: {ip}" for ifname, ip in ips_dict.items() if ip]
-        if active_ips:
-            # Display first available IP if wlan0/eth0 not found but others are
-            first_available = active_ips[0]
-            if len(first_available) > 16: # Truncate if too long
-                 first_available = first_available[:16]
-            line1_msg = first_available
-            if len(active_ips) > 1 and len(active_ips[1]) <= 16:
-                 line2_msg = active_ips[1][:16]
-        else:
-            line1_msg = "No IP Found"
-            line2_msg = "Check Network"
-
-    if line1_msg:
-        lcd.message(line1_msg, 1)
-    if line2_msg:
-        lcd.message(line2_msg, 2)
-    elif not line1_msg: # Should not happen if logic above is correct
-        lcd.message("Error display", 1)
-
-
-def main():
-    lcd = None
-    buzzer = None
-    lcd_initialized = False
-    buzzer_initialized = False
+    if not RPI_HW_AVAILABLE:
+        print("Running in MOCK hardware mode. Check console for simulated LCD/Buzzer output.")
 
     try:
-        # Initialize GPIO (using BCM mode is important)
-        GPIO.setmode(GPIO.BCM) # Set mode globally for all modules
-
-        # Initialize LCD
-        try:
-            print(f"Initializing LCD at I2C address 0x{LCD_I2C_ADDRESS:02X}...")
-            lcd = LCD_I2C(i2c_addr=LCD_I2C_ADDRESS)
-            lcd.message("LCD Init OK", 1)
-            print("LCD Initialized.")
-            lcd_initialized = True
-            time.sleep(0.5) # Short pause to display message
-        except Exception as e:
-            print(f"Error initializing LCD: {e}")
-            # If LCD fails, we can't display on it. Buzzer might still work.
-
-        # Initialize Buzzer
-        try:
-            print(f"Initializing Buzzer on GPIO {BUZZER_GPIO_PIN}...")
-            buzzer = PassiveBuzzer(buzzer_pin=BUZZER_GPIO_PIN)
-            print("Buzzer Initialized.")
-            # Play a confirmation beep - assuming confirmation_beep will be added to PassiveBuzzer
-            # If it's not there yet, this might cause a temporary error until step 2,
-            # or we can use an existing beep method for now.
-            # Using existing beep for now, will refine if new method is added.
-            buzzer.beep(repeat=2, tone_duration=0.05, pause_duration=0.05, frequency=1500)
-            buzzer_initialized = True
-            if lcd_initialized:
-                lcd.message("Buzzer Init OK", 2)
-            time.sleep(0.5) # Short pause
-        except Exception as e:
-            print(f"Error initializing Buzzer: {e}")
-            if lcd_initialized:
-                lcd.clear()
-                lcd.message("Buzzer Init FAIL", 1)
-                time.sleep(1)
-            # No buzzer sound possible if it failed.
-
-        # Combined status and startup sequence
-        if lcd_initialized and buzzer_initialized:
-            print("LCD and Buzzer OK. Playing startup sound...")
-            lcd.clear()
-            lcd.message("System Ready", 1)
-            lcd.message("IP Display Active", 2)
-            buzzer.startup_sound() # Original startup sound
-            time.sleep(1.5)
-        elif lcd_initialized:
-            lcd.clear()
-            lcd.message("Sys Ready (NoBuz)", 1) # System ready, but buzzer failed
-            time.sleep(1.5)
-        elif buzzer_initialized:
-            # If only buzzer works, play a different sound pattern to indicate LCD failure
-            print("LCD failed, Buzzer OK. Playing alert sound for LCD failure.")
-            buzzer.alert_sound() # Use alert sound to indicate an issue
-            time.sleep(1.5)
-        else:
-            # Both failed
-            print("CRITICAL: LCD and Buzzer failed to initialize.")
-            # No feedback possible via LCD/Buzzer. Console log is key.
-            time.sleep(1.5)
-
-
-        last_ips_displayed = {}
+        last_ip_str = ""
+        display_message("IP Display Util", "Fetching IP...", clear_first=True)
+        play_sound("startup") # Play startup sound via controller
+        time.sleep(1)
 
         while True:
-            current_ips = get_all_ips(NETWORK_INTERFACES)
+            current_ip_str = get_ip_addresses_string() # Use controller's IP fetcher
 
-            # Only update LCD if IPs have changed
-            if current_ips != last_ips_displayed:
-                print(f"IPs: {current_ips}")
-                display_ips_on_lcd(lcd, current_ips)
-                last_ips_displayed = current_ips.copy()
+            if current_ip_str != last_ip_str:
+                print(f"IPs: {current_ip_str}")
+                display_message("IP:", current_ip_str, clear_first=True) # Display using controller
+                last_ip_str = current_ip_str
 
-                # Optional: Beep if IP changes (can be annoying)
-                # if any(current_ips.values()): # Beep if at least one IP is found
-                #    buzzer.beep(repeat=1, tone_duration=0.05, frequency=1200)
-
-            # Wait for the refresh interval
-            # Implement a way to break this loop cleanly for shutdown if needed
-            # For now, Ctrl+C is the way.
+            # Wait for the refresh interval, sleeping in 1s chunks for responsiveness
             for _ in range(IP_REFRESH_INTERVAL):
-                time.sleep(1) # Sleep in 1s intervals to make Ctrl+C more responsive
+                time.sleep(1)
+                # In a more complex app, you might check for an exit signal here
 
     except KeyboardInterrupt:
-        print("\nShutting down...")
-        if buzzer_initialized and buzzer: # Check if buzzer was successfully initialized
-            buzzer.play_tone(200, 0.1) # Short low beep for shutdown
-            buzzer.play_tone(150, 0.1)
-        if lcd_initialized and lcd: # Check if lcd was successfully initialized
-            lcd.clear()
-            lcd.backlight(True) # Ensure backlight is on for message
-            lcd.message("System Off", 1)
-            time.sleep(1) # Give time to read
-            lcd.backlight(False) # Turn off backlight
-            lcd.display_off()
+        print("\nStandalone IP Display shutting down (Ctrl+C pressed)...")
     except Exception as e:
-        print(f"An error occurred in main loop: {e}")
-        if lcd_initialized and lcd: # Check if lcd was successfully initialized
-            lcd.clear()
-            try:
-                lcd.message("Runtime Error", 1)
-                error_str = str(e)[:16] # Display a snippet of the error
-                lcd.message(error_str, 2)
-            except Exception as lcd_ex:
-                print(f"Further error attempting to display on LCD: {lcd_ex}")
-        if buzzer_initialized and buzzer: # Check if buzzer was successfully initialized
-            try:
-                buzzer.alert_sound() # Play alert sound on error
-            except Exception as buzz_ex:
-                print(f"Error playing buzzer alert: {buzz_ex}")
+        print(f"An error occurred in Standalone IP Display: {e}")
+        if RPI_HW_AVAILABLE:
+            display_message("IP Display Error", str(e)[:16], clear_first=True)
+            play_sound("alert")
     finally:
-        print("Cleaning up GPIO...")
-        if buzzer_initialized and buzzer: # Buzzer cleanup does not call GPIO.cleanup() itself
-            buzzer.cleanup()
-        # LCD class does not directly use RPi.GPIO, so no specific cleanup for it here
-        # other than turning it off (already done in KeyboardInterrupt if LCD was init).
-        GPIO.cleanup() # Clean up all GPIO channels used
-        print("GPIO cleanup complete. Exiting.")
+        print("Calling hardware shutdown via controller...")
+        # The shutdown_hardware function from the controller will handle LCD messages, sounds, and GPIO cleanup.
+        shutdown_hardware()
+        print("Standalone IP Display finished.")
 
 if __name__ == "__main__":
-    main()
-# End of ip_display_app.py
+    main_ip_display()

--- a/run.py
+++ b/run.py
@@ -1,8 +1,60 @@
 import click
+import atexit
+import socket # For getting local IP
 from app import create_app, db
 from app.models import User, Student, Exam, Log # Import models to ensure they are known to Flask-Migrate
+from app.hardware_controller import init_hardware, shutdown_hardware, display_message, play_sound, RPI_HW_AVAILABLE
 
 app = create_app()
+
+# --- Hardware Integration ---
+def get_local_ip_for_display():
+    """Attempts to get the local IP address for display purposes."""
+    s = None
+    try:
+        # Try connecting to an external server to find the primary interface IP
+        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        s.connect(("8.8.8.8", 80)) # Google DNS
+        ip = s.getsockname()[0]
+    except Exception:
+        # Fallback: Try getting IP from hostname (might be 127.0.0.1 or internal)
+        try:
+            hostname = socket.gethostname()
+            ip = socket.gethostbyname(hostname)
+        except socket.gaierror:
+            ip = "?.?.?.?" # If all else fails
+    finally:
+        if s:
+            s.close()
+    return ip
+
+def initialize_app_hardware():
+    """Initializes hardware components when the Flask app starts."""
+    if RPI_HW_AVAILABLE:
+        server_ip = get_local_ip_for_display()
+        # Assuming Flask runs on port 5000 by default if not specified
+        server_port = app.config.get("SERVER_PORT", "5000")
+        if init_hardware(app_name=app.name.capitalize(), server_ip=server_ip, server_port=str(server_port)):
+            print("Hardware initialized successfully for Flask app.")
+            # Optional: display_message can be called here if a specific startup message is desired beyond init_hardware's default
+        else:
+            print("Hardware initialization failed for Flask app.")
+    else:
+        print("Flask app running in mock hardware mode (RPi hardware not detected/initialized).")
+
+def cleanup_app_hardware():
+    """Cleans up hardware components when the Flask app shuts down."""
+    if RPI_HW_AVAILABLE:
+        print("Shutting down hardware on Flask app exit...")
+        shutdown_hardware()
+    else:
+        print("Flask app (mock hardware mode) is shutting down.")
+
+# Register hardware initialization and cleanup
+# Note: init_hardware is called before app.run() to ensure it's done at startup.
+# atexit handles cleanup on normal interpreter exit.
+
+# --- End Hardware Integration ---
 
 @app.shell_context_processor
 def make_shell_context():
@@ -23,4 +75,16 @@ def create_admin_command(username, password):
     print(f"Admin user {username} created successfully.")
 
 if __name__ == '__main__':
-    app.run()
+    # Initialize hardware before starting the Flask development server
+    initialize_app_hardware()
+    # Register cleanup function to be called on exit
+    atexit.register(cleanup_app_hardware)
+
+    # Get host and port from Flask config or use defaults
+    # HOST and PORT can be set in config.py or via environment variables typically
+    host = app.config.get('HOST', '0.0.0.0')
+    port = app.config.get('PORT', 5000)
+    debug = app.config.get('DEBUG', False)
+
+    print(f"Starting Flask app on {host}:{port} (Debug: {debug})")
+    app.run(host=host, port=port, debug=debug)


### PR DESCRIPTION
- Centralized hardware (LCD, Buzzer) control in `app/hardware_controller.py`.
- `hardware_controller.py` manages GPIO.setmode and GPIO.cleanup.
- Includes mock mode for development on non-RPi systems.
- Modified `run.py` to initialize and shut down hardware on Flask app start/stop.
- LCD displays app status and IP; buzzer provides startup/shutdown sounds.
- Updated `ip_display_app.py` to use `hardware_controller.py`.
- Removed direct GPIO management from `buzzer_pwm.py`.
- Updated AGENTS.md and README.md to reflect new architecture and setup.