### PR TITLE
Add camera capture option for student registration

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -23,11 +23,7 @@ class StudentForm(FlaskForm):
         
         # Dynamically add/update validators for the photo field here
         # This ensures current_app is available because __init__ is called when an app context exists
-        current_photo_validators = []
-        if not original_student_id_number: # If creating a new student, photo is required
-            current_photo_validators.append(FileRequired(message='Photo is required for new students.'))
-        else: # If editing, photo is optional
-            current_photo_validators.append(Optional())
+        current_photo_validators = [Optional()] # Always optional, will validate in route
         
         # Add FileAllowed validator using current_app.config
         # This must be done after super().__init__() and within an app context scenario

--- a/app/templates/add_student.html
+++ b/app/templates/add_student.html
@@ -46,8 +46,27 @@
                 </div>
             {% endif %}
             <small class="form-text text-muted">
-                Upload a clear frontal face picture. Allowed formats: JPG, PNG.
+                Upload a clear frontal face picture (JPG, PNG) OR use the camera option below.
             </small>
+        </div>
+
+        <div class="form-group">
+            <label>Camera Option</label>
+            <div>
+                <button type="button" id="openCameraBtn" class="btn btn-info mb-2"><i class="fas fa-camera"></i> Open Camera</button>
+            </div>
+            <div id="cameraContainer" style="display: none; position: relative; width: 320px; height: 240px; border: 1px solid #ccc; margin-bottom: 10px;">
+                <video id="videoElement" width="320" height="240" autoplay style="display: block;"></video>
+                <button type="button" id="capturePhotoBtn" class="btn btn-primary" style="position: absolute; bottom: 10px; left: 50%; transform: translateX(-50%);">
+                    <i class="fas fa-camera-retro"></i> Capture Photo
+                </button>
+            </div>
+            <div id="capturePreviewContainer" style="display: none; margin-top:10px;">
+                <label>Captured Photo Preview:</label><br>
+                <img id="capturedImagePreview" src="#" alt="Captured Photo" style="max-width: 320px; max-height: 240px; border: 1px solid #ddd;"/>
+                <button type="button" id="retakePhotoBtn" class="btn btn-warning ml-2"><i class="fas fa-redo"></i> Retake</button>
+            </div>
+            <input type="hidden" name="captured_image_data" id="captured_image_data">
         </div>
 
         <hr>
@@ -61,4 +80,95 @@
         </div>
     </form>
 </div>
+
+{% block scripts %}
+{{ super() }}
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+    const openCameraBtn = document.getElementById('openCameraBtn');
+    const capturePhotoBtn = document.getElementById('capturePhotoBtn');
+    const retakePhotoBtn = document.getElementById('retakePhotoBtn');
+    const videoElement = document.getElementById('videoElement');
+    const cameraContainer = document.getElementById('cameraContainer');
+    const capturedImagePreview = document.getElementById('capturedImagePreview');
+    const capturePreviewContainer = document.getElementById('capturePreviewContainer');
+    const capturedImageDataInput = document.getElementById('captured_image_data');
+    const photoFileInput = document.querySelector('input[type="file"][name="photo"]');
+
+    let stream = null;
+
+    openCameraBtn.addEventListener('click', async () => {
+        if (typeof navigator.mediaDevices.getUserMedia !== 'function') {
+            alert('Camera access is not supported by your browser.');
+            return;
+        }
+        try {
+            stream = await navigator.mediaDevices.getUserMedia({ video: { width: 320, height: 240 } });
+            videoElement.srcObject = stream;
+            cameraContainer.style.display = 'block';
+            openCameraBtn.style.display = 'none';
+            capturePhotoBtn.style.display = 'inline-block'; // Or 'block'
+            capturePreviewContainer.style.display = 'none'; // Hide preview when camera opens
+            capturedImageDataInput.value = ''; // Clear any previous capture
+            photoFileInput.value = ''; // Clear file input if camera is used
+        } catch (err) {
+            console.error("Error accessing camera: ", err);
+            alert('Could not access the camera. Please ensure permission is granted and no other application is using it.');
+        }
+    });
+
+    capturePhotoBtn.addEventListener('click', () => {
+        if (!stream) return;
+
+        const canvas = document.createElement('canvas');
+        canvas.width = videoElement.videoWidth;
+        canvas.height = videoElement.videoHeight;
+        const context = canvas.getContext('2d');
+        context.drawImage(videoElement, 0, 0, canvas.width, canvas.height);
+
+        const dataUrl = canvas.toDataURL('image/jpeg');
+        capturedImagePreview.src = dataUrl;
+        capturedImageDataInput.value = dataUrl;
+
+        capturePreviewContainer.style.display = 'block';
+        cameraContainer.style.display = 'none'; // Hide camera view
+        capturePhotoBtn.style.display = 'none';
+        retakePhotoBtn.style.display = 'inline-block';
+
+        // Stop the camera stream
+        if (stream) {
+            stream.getTracks().forEach(track => track.stop());
+            stream = null;
+        }
+        videoElement.srcObject = null; // Clear video element source
+        openCameraBtn.style.display = 'inline-block'; // Show "Open Camera" again
+                                                   // or a dedicated "Retake" button could show Open Camera
+    });
+
+    retakePhotoBtn.addEventListener('click', () => {
+        capturedImageDataInput.value = '';
+        capturedImagePreview.src = '#';
+        capturePreviewContainer.style.display = 'none';
+        retakePhotoBtn.style.display = 'none';
+        openCameraBtn.click(); // Re-open camera
+    });
+
+    // If a file is selected, clear the captured image data
+    photoFileInput.addEventListener('change', function() {
+        if (this.files && this.files.length > 0) {
+            capturedImageDataInput.value = '';
+            capturedImagePreview.src = '#';
+            capturePreviewContainer.style.display = 'none';
+            if (stream) { // Stop camera if it was open
+                stream.getTracks().forEach(track => track.stop());
+                stream = null;
+                videoElement.srcObject = null;
+                cameraContainer.style.display = 'none';
+                openCameraBtn.style.display = 'inline-block';
+                capturePhotoBtn.style.display = 'none';
+            }
+        }
+    });
+});
+</script>
 {% endblock %}

--- a/app/utils.py
+++ b/app/utils.py
@@ -7,24 +7,56 @@ def allowed_file(filename):
     return '.' in filename and \
            filename.rsplit('.', 1)[1].lower() in current_app.config['ALLOWED_EXTENSIONS']
 
-def process_student_image(photo_file, student_id_number):
+def process_student_image(image_input, student_id_number, source_type='fileupload'):
     """
-    Saves the student's photo, extracts face embedding, and returns image path and embedding.
-    Returns: (image_path, face_embedding) or (None, None) if error or no face found.
+    Saves the student's photo (from upload or capture), extracts face embedding,
+    and returns image filename and embedding.
+    Args:
+        image_input: Can be a FileStorage object (uploaded file) or BytesIO (captured image).
+        student_id_number: The student's ID number.
+        source_type: 'fileupload' or 'capture'.
+    Returns: (filename, face_embedding) or (None, error_message) if error or no face found.
     """
-    if photo_file is None or not photo_file.filename:
-        return None, None # No file uploaded
+    if image_input is None:
+        return None, "No image data provided."
 
-    if allowed_file(photo_file.filename):
-        filename = secure_filename(f"student_{student_id_number}_{photo_file.filename}")
-        upload_folder = current_app.config['UPLOAD_FOLDER']
+    upload_folder = current_app.config['UPLOAD_FOLDER']
+    filename = None
+    image_path = None
+
+    if source_type == 'fileupload':
+        if not hasattr(image_input, 'filename') or not image_input.filename:
+             return None, "Invalid file upload."
+        if not allowed_file(image_input.filename):
+            return None, "File type not allowed for upload."
+        # Secure the original filename for uploads
+        base_filename = image_input.filename.rsplit('.', 1)[0] # Get name without extension
+        extension = image_input.filename.rsplit('.', 1)[1].lower()
+        filename = secure_filename(f"student_{student_id_number}_{base_filename}.{extension}")
         image_path = os.path.join(upload_folder, filename)
-
         try:
-            photo_file.save(image_path)
+            image_input.save(image_path)
+        except Exception as e:
+            return None, f"Error saving uploaded file: {str(e)}"
 
-            # Load the saved image and find face encodings
-            image = face_recognition.load_image_file(image_path)
+    elif source_type == 'capture':
+        # For captured images (BytesIO), generate a filename. Assuming JPEG format from canvas.toDataURL('image/jpeg')
+        filename = secure_filename(f"student_{student_id_number}_capture.jpg")
+        image_path = os.path.join(upload_folder, filename)
+        try:
+            with open(image_path, 'wb') as f:
+                f.write(image_input.getbuffer()) # BytesIO object has getbuffer()
+        except Exception as e:
+            return None, f"Error saving captured image: {str(e)}"
+    else:
+        return None, "Invalid image source type."
+
+    if not image_path: # Should not happen if logic above is correct
+        return None, "Failed to determine image path."
+
+    try:
+        # Load the saved image and find face encodings
+        image = face_recognition.load_image_file(image_path)
             face_encodings = face_recognition.face_encodings(image)
 
             if face_encodings:


### PR DESCRIPTION
This feature allows users to capture an image directly from their device's camera when adding a new student, as an alternative to uploading an image file.

Key changes:
- Modified StudentForm to make photo upload optional.
- Updated add_student.html template with HTML and JavaScript for camera access, image capture, and preview.
- Modified the add_student route in routes.py to handle base64 encoded image data from the camera capture and validate that an image (either uploaded or captured) is provided.
- Adapted the process_student_image utility in utils.py to handle both FileStorage objects (for uploads) and BytesIO objects (for captured images), saving them appropriately before face detection and embedding extraction.
- Added clearing of face cache after new student addition to ensure immediate availability for recognition.