### PR TITLE
Fix: Correct URL generation for sorting in view_logs.html

### DIFF
--- a/app/templates/view_logs.html
+++ b/app/templates/view_logs.html
@@ -50,8 +50,10 @@
                 {# Helper macro for sortable table headers #}
                 {% macro sortable_th(column_key, display_name, current_sort_by, current_sort_order) %}
                     {% set new_sort_order = 'asc' if current_sort_by == column_key and current_sort_order == 'desc' else 'desc' %}
+                    {% set query_params = request.args.to_dict() %}
+                    {% do query_params.update({'sort_by': column_key, 'sort_order': new_sort_order, 'page': 1}) %}
                     <th scope="col">
-                        <a href="{{ url_for('main.view_logs', page=request.args.get('page', 1), sort_by=column_key, sort_order=new_sort_order, **request.args.to_dict(flat=False)|rejectattr('sort_by', 'equalto', current_sort_by)|list|selectattr(0, 'ne', 'sort_order')|selectattr(0, 'ne', 'page')|dict) }}" class="text-white">
+                        <a href="{{ url_for('main.view_logs', **query_params) }}" class="text-white">
                             {{ display_name }}
                             {% if current_sort_by == column_key %}
                                 <i class="fas fa-sort-{{ 'up' if current_sort_order == 'asc' else 'down' }}"></i>


### PR DESCRIPTION
This commit resolves a `jinja2.exceptions.TemplateAssertionError: No filter named 'dict'` that occurred in `app/templates/view_logs.html` when generating sorting links for table headers.

The problematic Jinja expression, which relied on a non-standard `|dict` filter and a complex chain of operations, has been replaced with a clearer method:
1. Existing request arguments are copied into a new dictionary.
2. 'sort_by', 'sort_order', and 'page' (reset to 1) parameters are updated in this dictionary.
3. The dictionary is then passed to `url_for` using `**kwargs`.

This ensures that filter parameters are preserved while sorting parameters are correctly applied.