### PR TITLE
Fix: Resolve TemplateSyntaxError in view_logs.html sorting links

### DIFF
--- a/app/templates/view_logs.html
+++ b/app/templates/view_logs.html
@@ -50,10 +50,14 @@
                 {# Helper macro for sortable table headers #}
                 {% macro sortable_th(column_key, display_name, current_sort_by, current_sort_order) %}
                     {% set new_sort_order = 'asc' if current_sort_by == column_key and current_sort_order == 'desc' else 'desc' %}
-                    {% set query_params = request.args.to_dict() %}
-                    {% do query_params.update({'sort_by': column_key, 'sort_order': new_sort_order, 'page': 1}) %}
                     <th scope="col">
-                        <a href="{{ url_for('main.view_logs', **query_params) }}" class="text-white">
+                        <a href="{{ url_for('main.view_logs',
+                                        sort_by=column_key,
+                                        sort_order=new_sort_order,
+                                        page=1,
+                                        filter_date=request.args.get('filter_date'),
+                                        filter_exam_id=request.args.get('filter_exam_id'),
+                                        filter_student_id=request.args.get('filter_student_id')) }}" class="text-white">
                             {{ display_name }}
                             {% if current_sort_by == column_key %}
                                 <i class="fas fa-sort-{{ 'up' if current_sort_order == 'asc' else 'down' }}"></i>


### PR DESCRIPTION
This commit fixes a `jinja2.exceptions.TemplateSyntaxError: Encountered unknown tag 'do'` in `app/templates/view_logs.html`.

The error was caused by using the `{% do %}` tag, which is a Jinja2 extension not enabled by default in the environment.

The fix involves refactoring the URL generation within the `sortable_th` macro:
- Removed the use of `{% do %}` and intermediate dictionary manipulation for query parameters.
- The `url_for` call now explicitly includes `sort_by`, `sort_order`, `page` (hardcoded to 1 for new sorts), and retrieves current filter values (`filter_date`, `filter_exam_id`, `filter_student_id`) using `request.args.get()`.

This ensures that sorting links are generated correctly while preserving active filters, without relying on non-standard Jinja2 extensions.